### PR TITLE
Add minimal Next.js app structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# E-achat
+# ProcureFlow
+
+ProcureFlow is a Next.js application configured with Tailwind CSS and Radix UI components. The repository provides a minimal starting point for building a modern procurement platform.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+## Project Structure
+
+- `app/` – Contains the Next.js App Router pages and global styles.
+- `components/` – Placeholder for shared UI components.
+- `tailwind.config.ts` – Tailwind CSS configuration.
+- `tsconfig.json` – TypeScript configuration targeting **ESNext**.
+
+## Dependencies
+
+The project uses Tailwind CSS, Radix UI, and other utilities such as React Hook Form and Zod for form validation.
+
+## Screenshots
+
+You can add interface screenshots here once the UI is fully implemented.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-background text-foreground min-h-screen;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,10 @@
+export default function HomePage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-4">
+      <h1 className="text-3xl font-bold">Welcome to ProcureFlow</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        This is a starter page using the Next.js App Router.
+      </p>
+    </main>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- create `app` directory with global styles and a simple page
- update `tsconfig.json` to target ESNext
- expand `README` with setup and project info

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f46c9a45083329f1310f65b2c8148